### PR TITLE
Feat/require stripe account for live meal

### DIFF
--- a/src/components/OwnerAssetCard.vue
+++ b/src/components/OwnerAssetCard.vue
@@ -8,11 +8,15 @@ import logger from 'src/utils/logger'
 import ConfirmDeleteDialog from 'src/components/ConfirmDeleteDialog'
 
 import { isAvailable } from 'src/utils/asset'
+import StripeMixin from 'src/mixins/stripe'
 
 export default {
   components: {
     ConfirmDeleteDialog,
   },
+  mixins: [
+    StripeMixin,
+  ],
   props: {
     asset: {
       type: Object,
@@ -70,6 +74,7 @@ export default {
     }),
     ...mapGetters([
       'conversations',
+      'stripeActive',
     ])
   },
   created () {
@@ -229,24 +234,32 @@ export default {
         class="row justify-end q-mt-sm q-mb-md"
         @click.prevent
       >
-        <QBtn
-          v-if="!unavailable"
-          :loading="updatingStatus"
-          :rounded="style.roundedTheme"
-          color="grey-2"
-          text-color="default-color"
-          unelevated
-          @click.stop.prevent="toggleActive"
-        >
-          <QIcon
-            :name="paused ? icons.matPlayArrow : icons.matPause"
-            :left="true"
-          />
+        <div>
           <AppContent
-            entry="asset"
-            :field="paused ? 'reactivate_action' : 'pause_action'"
+            v-if="(!hasLinkedStripeAccount && !!paused)"
+            tag="QTooltip"
+            entry="user"
+            field="account.stripe.link_account_reminder"
           />
-        </QBtn>
+          <QBtn
+            :disabled="(!hasLinkedStripeAccount && !!paused)"
+            :loading="updatingStatus"
+            :rounded="style.roundedTheme"
+            color="grey-2"
+            text-color="default-color"
+            unelevated
+            @click.stop.prevent="toggleActive"
+          >
+            <QIcon
+              :name="paused ? icons.matPlayArrow : icons.matPause"
+              :left="true"
+            />
+            <AppContent
+              entry="asset"
+              :field="paused ? 'reactivate_action' : 'pause_action'"
+            />
+          </QBtn>
+        </div>
         <QBtn
           :loading="removingAsset"
           :rounded="style.roundedTheme"

--- a/src/i18n/source/navigation.yaml
+++ b/src/i18n/source/navigation.yaml
@@ -6,7 +6,7 @@ navigation:
     en: FAQ
     fr: "Comment ça marche\_?"
   new_listing:
-    en: Publish your add
+    en: Sell a meal
     fr: Publiez votre annonce
   new_listing__EDITOR_LABEL:
     en: New listing link

--- a/src/i18n/source/transaction.yaml
+++ b/src/i18n/source/transaction.yaml
@@ -152,3 +152,6 @@ transaction:
     unavailable_periods:
       en: The selected dates are not available.
       fr: Les dates sélectionnées ne sont pas disponibles.
+    seller_unavailable:
+      en: The seller is not ready to accept payments. Message them to arrange your purchase.
+      en: The seller is not ready to accept payments. Message them to arrange your purchase.    

--- a/src/i18n/source/user.yaml
+++ b/src/i18n/source/user.yaml
@@ -184,6 +184,9 @@ user:
       link_account_title:
         en: Stripe
         fr: Stripe
+      link_account_reminder:
+        en: Link a Stripe account to start selling.
+        fr: Link a Stripe account to start selling.
       link_account_notification_message:
         en: Please link a Stripe account in your profile to receive payments.
         fr: Merci de lier un compte Stripe dans votre page profil pour recevoir les paiements.

--- a/src/layouts/MainLayoutHeader.vue
+++ b/src/layouts/MainLayoutHeader.vue
@@ -8,7 +8,8 @@ import {
   matLock,
   matMail,
   matPowerSettingsNew,
-  matSearch
+  matSearch,
+  matWarning
 } from '@quasar/extras/material-icons'
 import { mdiGithubCircle } from '@quasar/extras/mdi-v4'
 
@@ -23,6 +24,7 @@ import PlacesAutocomplete from 'src/components/PlacesAutocomplete'
 
 import AuthDialogMixin from 'src/mixins/authDialog'
 import GeolocationMixin from 'src/mixins/geolocation'
+import StripeMixin from 'src/mixins/stripe'
 
 export default {
   components: {
@@ -36,6 +38,7 @@ export default {
   mixins: [
     AuthDialogMixin,
     GeolocationMixin,
+    StripeMixin,
   ],
   data () {
     return {
@@ -90,6 +93,12 @@ export default {
     showGithubForkButton () {
       return process.env.VUE_APP_GITHUB_FORK_BUTTON === 'true'
     },
+    ownAssets () {
+      return this.usersAssets[this.currentUser.id] || []
+    },
+    needsStripeLink () {
+      return this.ownAssets.length >= 1 && !this.hasLinkedStripeAccount
+    },
     ...mapState([
       'common',
       'content',
@@ -106,6 +115,8 @@ export default {
       'defaultSearchMode',
       'currentUserPosition',
       'displayAssetDistance',
+      'stripeActive',
+      'usersAssets',
     ]),
   },
   watch: {
@@ -138,6 +149,7 @@ export default {
 
         if (this.isSearch) this.searchAssets()
         if (current.id) await this.$store.dispatch('fetchMessages')
+        if (current.id) await this.checkForStripeLink()
       }
     },
   },
@@ -154,6 +166,7 @@ export default {
         })
       }
     }
+    await this.checkForStripeLink()
   },
   created () {
     this.icons = {
@@ -163,10 +176,14 @@ export default {
       matMail,
       matSearch,
       matPowerSettingsNew,
-      mdiGithubCircle
+      mdiGithubCircle,
+      matWarning
     }
   },
   methods: {
+    async checkForStripeLink () {
+      if (this.currentUser.id) await this.$store.dispatch('fetchUserAssets')
+    },
     toggleMenu (visible = !this.isMenuOpened) {
       this.$store.commit(mutationTypes.LAYOUT__TOGGLE_MENU, { visible })
     },
@@ -360,6 +377,25 @@ export default {
       </QBtn>
 
       <QBtn
+        v-if="currentUser.id"
+        v-show="needsStripeLink"
+        :to="{ name: 'publicProfile', params: { id: currentUser.id } }"
+        :class="['q-mx-md header__inbox', isMenuOpened ? 'invisible' : '']"
+        :aria-label="$t({ id: 'navigation.public_profile' })"
+        :rounded="style.roundedTheme"
+        color="primary"
+        dense
+        :icon="icons.matWarning"
+      >
+        <AppContent
+          v-if="!hasLinkedStripeAccount"
+          tag="QTooltip"
+          entry="user"
+          field="account.stripe.link_account_helper_button"
+        />
+      </QBtn>
+
+      <QBtn
         v-show="!currentUser.id"
         flat
         no-caps
@@ -403,6 +439,7 @@ export default {
         align="between"
         dense
       />
+      <!-- TODO: make an icon button that shows on iPad screen sizes -->
 
       <QBtn
         v-if="currentUser.id && showAccountAvatar"

--- a/src/pages/Asset.vue
+++ b/src/pages/Asset.vue
@@ -29,6 +29,17 @@
             color="warning"
             text-color="white"
           />
+          <AppContent
+            v-if="activeAsset.id && isCurrentUserTheOwner && !hasLinkedStripeAccount"
+            class="text-uppercase non-selectable"
+            tag="QBtn"
+            entry="user"
+            field="account.stripe.link_account_reminder"
+            :rounded="style.roundedTheme"
+            color="primary"
+            text-color="white"
+            @click="goToProfile"
+          />
 
           <AppContent
             v-if="activeAsset.startDate"

--- a/src/pages/Asset.vue
+++ b/src/pages/Asset.vue
@@ -334,6 +334,7 @@ import TransactionRatingsList from 'src/components/TransactionRatingsList'
 
 import PageComponentMixin from 'src/mixins/pageComponent'
 import PaymentMixin from 'src/mixins/payment'
+import StripeMixin from 'src/mixins/stripe'
 
 export default {
   components: {
@@ -348,6 +349,7 @@ export default {
   mixins: [
     PageComponentMixin,
     PaymentMixin,
+    StripeMixin,
   ],
   data () {
     return {
@@ -448,6 +450,7 @@ export default {
       'ratingsActive',
       'paymentActive',
       'conversations',
+      'stripeActive',
     ]),
   },
   watch: {
@@ -497,6 +500,9 @@ export default {
       // with server-side rendering (SSR)
       this.fetchRelatedAssets()
       this.fetchAssetRatingsByTransaction()
+    },
+    goToProfile () {
+      return this.$router.push({ name: 'publicProfile', params: { id: this.currentUser.id } })
     },
     toggleImageEdition (editing) {
       this.isEditingImages = typeof editing === 'boolean'

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -285,15 +285,15 @@ export default {
           <!-- TODO: remove WebP test when upgrading to AWS image handler version supporting AUTO_WEBP -->
           <source
             :srcset="`${
-              getHomeHeroUrlTransformed({ noWebP: true, width: 1024 })
+              getHomeHeroUrlTransformed({ width: 1024 })
             } 1024w, ${
-              getHomeHeroUrlTransformed({ noWebP: true, width: 1366 })
+              getHomeHeroUrlTransformed({ width: 1366 })
             } 1366w, ${
-              getHomeHeroUrlTransformed({ noWebP: true, width: 1600 })
+              getHomeHeroUrlTransformed({ width: 1600 })
             } 1600w, ${
-              getHomeHeroUrlTransformed({ noWebP: true, width: 1920 })
+              getHomeHeroUrlTransformed({ width: 1920 })
             } 1920w, ${
-              getHomeHeroUrlTransformed({ noWebP: true, width: 2560 })
+              getHomeHeroUrlTransformed({ width: 2560 })
             } 2560w`"
             sizes="100vw"
             media="(min-width: 640px)"

--- a/src/pages/NewAsset.vue
+++ b/src/pages/NewAsset.vue
@@ -283,7 +283,8 @@ export default {
             locations: this.locations,
             categoryId: this.selectedCategory ? this.selectedCategory.id : null,
             customAttributes: pick(this.editingCustomAttributes, this.editableCustomAttributeNames),
-            active: true,
+            // new assets should be inacitve if stripe account has not been linked
+            active: this.hasLinkedStripeAccount,
             validated: true,
             metadata: {
               images,

--- a/src/store/content/state.js
+++ b/src/store/content/state.js
@@ -21,7 +21,7 @@ export default {
   appUpdateNoCache: true,
 
   placeholderImageBaseUrl: 'https://placeimg.com',
-  acceptWebP: false,
+  acceptWebP: true,
   // http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
   blankImageBase64: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
 


### PR DESCRIPTION
fixes #4, #5 by making new meals inactive by default, and showing notifications to the seller in several places (header, asset page).
Also, if the seller has a meal live, then their Stripe account becomes un-linked, the buyer and seller will be put into a message thread so the seller will be aware people want to buy their stuff, but cannot.